### PR TITLE
Source control useractions for projects ignored `"objectscript.serverSourceControl.disableOtherActionTriggers": true` setting

### DIFF
--- a/src/commands/studio.ts
+++ b/src/commands/studio.ts
@@ -106,6 +106,13 @@ export class StudioActions {
 
   /** Fire UserAction `id` on server `api` for project `name`. */
   public async fireProjectUserAction(api: AtelierAPI, name: string, id: OtherStudioAction): Promise<void> {
+    const scope = api.wsOrFile instanceof vscode.Uri ? api.wsOrFile : this.uri;
+    if (
+      vscode.workspace.getConfiguration("objectscript.serverSourceControl", scope)?.get("disableOtherActionTriggers")
+    ) {
+      this.projectEditAnswer = "1";
+      return;
+    }
     this.api = api;
     this.name = `${name}.PRJ`;
     return this.userAction(


### PR DESCRIPTION
Fixes an issue reported by a Deltanji user., caused by the project-level source control calls added in 2.12.2.

The setting previously added to allow Deltanji sites to suppress user action calls was not bei8ng respected.